### PR TITLE
[ADD] 특정 회원에 대한 측정 기록과 측정 데이터 생성하기

### DIFF
--- a/controllers/measurement.js
+++ b/controllers/measurement.js
@@ -1,5 +1,24 @@
 const { get } = require("../routes/measurement.js");
-const measurementService = require("../services/measurement.js");
+const measurementService = require("../services/measurement");
+
+const createMeasurementData = async (req, res) => {
+  try {
+    const user_id = req.params.userId;
+    const { weight, type_data } = req.body;
+  
+    if (!weight || !type_data) {
+      const error = new Error("데이터를 확인해주세요.");
+      error.statusCode = 400;
+      throw error;
+    }
+    await measurementService.createMeasurementData(user_id, weight, type_data)
+    res.status(201).json({message : "측정 기록 생성 성공"})
+
+  } catch (err) {
+    console.log(err);
+    res.status(err.statusCode || 500).json({ message: err.message });
+  }
+}
 
 const getMeasurementData = async (req, res) => {
   let { date1, date2, weight1, weight2 } = req.query;
@@ -104,8 +123,9 @@ const deleteMeasurementData = async (req, res) => {
     res.status(400).json({ message: "error" });
   }
 };
-
+  
 module.exports = {
+  createMeasurementData,
   getMeasurementData,
   deleteMeasurementData,
 };

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -82,15 +82,22 @@ CREATE TABLE `users` (
   `birth` varchar(50) DEFAULT NULL,
   `height` decimal(4,1) DEFAULT NULL,
   `phone` varchar(50) DEFAULT NULL,
+<<<<<<< HEAD
   `deleted` varchar(50) DEFAULT '0',
+=======
+>>>>>>> 2d1fc67 ([ADD] 특정 회원에 대한 측정 기록과 측정 데이터 생성하기)
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+<<<<<<< HEAD
 
 -- Dumping routines for database 'bodit_2nd'
 
+=======
+-- Dumping routines for database 'bodit'
+>>>>>>> 2d1fc67 ([ADD] 특정 회원에 대한 측정 기록과 측정 데이터 생성하기)
 --
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -117,7 +124,11 @@ INSERT INTO `schema_migrations` (version) VALUES
   ('20221004095255'),
   ('20221004095321'),
   ('20221004095332'),
+<<<<<<< HEAD
   ('20221004095346'),
   ('20221006044656');
 
+=======
+  ('20221004095346');
+>>>>>>> 2d1fc67 ([ADD] 특정 회원에 대한 측정 기록과 측정 데이터 생성하기)
 UNLOCK TABLES;

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,5 +6,6 @@ const measurementRouter = require("./measurement");
 
 router.use("/users", usersRouter);
 router.use("", measurementRouter);
+router.use("/measurement-data", measurementRouter);
 
 module.exports = router;

--- a/routes/measurement.js
+++ b/routes/measurement.js
@@ -8,5 +8,6 @@ router.delete(
   "/measurement/:measurementId",
   measurementController.deleteMeasurementData,
 );
+router.post("/user/:userId", measurementController.createMeasurementData);
 
 module.exports = router;

--- a/services/measurement.js
+++ b/services/measurement.js
@@ -1,4 +1,98 @@
 const measurementModel = require("../models/measurement");
+const {
+  validateWeight,
+  validateWristMobility,
+  validateShoulderFlexion,
+  validateShoulderExtension,
+  validateWalking,
+  validateBreathingBalance } = require("../utils/validation")
+
+const createMeasurementData = async (user_id, weight, dataTypeArr) => {
+  
+  // 존재하는 유저id인지 확인
+  const userCheck = await measurementModel.getUserByUserId(user_id);
+  
+  if (!userCheck) {
+    const error = new Error("존재하지 않는 유저 ID입니다.");
+    error.statusCode = 404;
+    throw error;
+  }
+  
+  // 몸무게 유효성 체크
+  validateWeight(weight)
+  
+  let measurementData = [];
+  let data_id;
+  let value;
+  
+  // 존재하는 data_type_id인지 확인
+  for (let i = 0; i < dataTypeArr.length; i++) {
+    data_id = dataTypeArr[i].data_id
+    value = dataTypeArr[i].value
+      
+    const dataTypeIdCheck = await measurementModel.getDataTypeIdByTypeId(data_id)
+  
+    if (!dataTypeIdCheck) {
+      const error = new Error("존재하지 않는 데이터 타입 ID입니다.");
+      error.statusCode = 404;
+      throw error;
+    }
+  
+    // 데이터타입 유효성 검사
+    if (data_id === 1) {
+      validateWristMobility(value);
+    } else if (data_id === 2) {
+      // data_type_id가 2나 3이면 두개데이터 동시에 와야한다.
+      if (!(dataTypeArr[i + 1]) || (dataTypeArr[i + 1].data_id !== 3)) {
+        const error = new Error("어깨신전 데이터(3번)가 같이 필요합니다.");
+        error.statusCode = 400;
+        throw error;
+      } else {
+        validateShoulderFlexion(value);
+        validateShoulderExtension(dataTypeArr[i+1].value);
+      }
+    } else if (data_id === 3) {
+      // data_type_id가 2나 3이면 두개데이터 동시에 와야한다.
+      if (!(dataTypeArr[i - 1]) || (dataTypeArr[i - 1].data_id !== 2)) {
+        const error = new Error("어깨굴곡 데이터(2번)가 같이 필요합니다.");
+        error.statusCode = 400;
+        throw error;
+      }
+    } else if (data_id === 4) {
+      validateWalking(value)
+    } else if (data_id === 5) {
+      validateBreathingBalance(value)
+    }
+  
+    // 유효성 검사 끝
+    measurementData.push({
+      measurement_id: null,
+      data_type_id  : data_id,
+      data          : value
+    })
+  }
+  
+  // 같은 유저 아이디, 몸무게의 측정 기록이 이미 존재하는가?
+  const measurementCheck = await measurementModel.getMeasurementByUserIdAndWeight(user_id, weight)
+
+  if (measurementCheck) {
+    // 측정 기록 존재
+    const measurementDataCheck = await measurementModel.getMeasurementDataByIdAndTypeId(measurementCheck.id, data_id)
+    if (measurementDataCheck) {
+      // 측정 데이터 존재
+      const error = new Error("측정 데이터의 종류가 중복됩니다.");
+      error.statusCode = 409;
+      throw error;
+    } else {
+      // 측정 데이터 존재 X
+      await measurementModel.createOnlyMeasurementData(measurementCheck.id, measurementData)
+      return
+    }
+  }
+
+  // 모든 검사 끝 => 새 데이터 생성
+  await measurementModel.createMeasurementData(user_id, weight, measurementData)
+};
 
 const getMeasurementData = async (date1, date2, weight1, weight2) => {
   if (weight1 == undefined) {
@@ -36,6 +130,7 @@ const deleteMeasurementData = async (measurementId) => {
 };
 
 module.exports = {
+  createMeasurementData,
   getMeasurementData,
   deleteMeasurementData,
 };

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -1,0 +1,62 @@
+const validateWeight = (weight) => {
+  const weightRegExp = /^(\d{2,3})+(?:[.]?[\d]?)$/;
+  if (!weightRegExp.test(weight)) {
+    const err = new Error("몸무게는 소수점 한자리까지 가능합니다.");
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+const validateWristMobility = (data) => {
+  const wristMobilityRegExp = /^[0-9]{1}$|^[1-8]{1}[0-9]{1}$|^9{1}0{1}$/;
+  if (!wristMobilityRegExp.test(data)) {
+    const err = new Error("1 - 손목 가동성의 범위가 벗어났습니다. ");
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+const validateShoulderFlexion = (data) => {
+  const shoulderFlexionRegExp = /^[3-9]{1}[0-9]{1}$|^1{1}[0-6]{1}[0-9]{1}$|^1{1}7{1}0{1}$/;
+  if (!shoulderFlexionRegExp.test(data)) {
+    const err = new Error("2 - 어깨 굴곡의 범위가 벗어났습니다.");
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+const validateShoulderExtension = (data) => {
+  const shoulderRegExp = /^-[3-5]{1}[0-9]{1}$|^-6{1}0{1}$/;
+  if (!shoulderRegExp.test(data)) {
+    const err = new Error("3 - 어깨 신전의 범위가 벗어났습니다.");
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+const validateWalking = (data) => {
+  const walkingRegExp = /^[0-9]{1}$|^[1-9]{1}[0-9]{1}$|^1{1}0{1}0{1}$/;
+  if (!walkingRegExp.test(data)) {
+    const err = new Error("4 - 보행의 범위가 벗어났습니다.");
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+const validateBreathingBalance = (data) => {
+  const breathingBalanceRegExp = /^-?[0-9]{1}$|^-?[1-9]{1}[0-9]{1}$|^-?1{1}0{1}0{1}$/;
+  if (!breathingBalanceRegExp.test(data)) {
+    const err = new Error("5 - 호흡 균형의 범위가 벗어났습니다.");
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+module.exports = {
+  validateWeight,
+  validateWristMobility,
+  validateShoulderFlexion,
+  validateShoulderExtension,
+  validateWalking,
+  validateBreathingBalance,
+};


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 특정 회원에 대한 측정 기록과 측정 데이터 생성하기

<br />

## :: 구현 사항 설명
1. 측정 데이터 유효성 검사
  - utils에 따로 작성

2. 측정 기록(measurements) 생성
  - user_id 존재 유무 검사
  - weight 유효성 검사

3. 측정 데이터(measurement_data) 생성
  - measurement_id 필요
  - type_data 들어왔나 확인(키에러)
  - 어깨굴곡와 어깨신전은 한세트
  - 값의 유효성 검사
  - 측정기록 생성 후 측정 데이터 생성 트랜잭션 처리
  - 하나의 측정 기록에 맵핑되는 측정 데이터의 종류는 중복되면 안된다.

<br />

## :: 성장 포인트
  - 노드와 더 멀어졌습니다.

<br />

## :: 기타 질문 및 특이 사항
  - 코드가 너무 지저분해서 죄송합니다 ㅠㅠ 