### PR TITLE
[ADD] 데이터 빈배열 반환시 에러캐치 부분 추가

### DIFF
--- a/controllers/measurement.js
+++ b/controllers/measurement.js
@@ -1,3 +1,4 @@
+const { get } = require("../routes/measurement.js");
 const measurementService = require("../services/measurement.js");
 
 const getMeasurementData = async (req, res) => {
@@ -48,6 +49,12 @@ const getMeasurementData = async (req, res) => {
       weight1,
       weight2,
     );
+
+    if (getMeasurementData.length === 0) {
+      res
+        .status(200)
+        .json({ message: "설정하신 범위에 일치하는 데이터가 없습니다." });
+    }
     res.status(200).json(getMeasurementData);
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 범위에 일치하는 데이터가 없을시 빈 배열을 반환하는데 그럴때 일치하는 데이터가 없다는 문구 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 특정 측정 기록 및 측정 데이터 가져오기 부분 에러캐치.
- 설정된 범위안에 데이터가 없을시 빈 배열을 반환하는데 그럴때 빈 배열이 아닌 status코드 200번과 함께 "정해진 범위에 해당하는 데이터가 없습니다" 반환

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 빈배열을 반환한다고 성공이 아닌 세세한 부분에도 신경써서 결과값을 반환해야하는걸 느꼈습니다.

<br />

## :: 기타 질문 및 특이 사항

